### PR TITLE
[security] SMTP smuggling: update short term fix (#2346)

### DIFF
--- a/setup/mail-postfix.sh
+++ b/setup/mail-postfix.sh
@@ -72,7 +72,8 @@ tools/editconf.py /etc/postfix/main.cf \
 # Guard against SMTP smuggling
 # This short-term workaround is recommended at https://www.postfix.org/smtp-smuggling.html
 tools/editconf.py /etc/postfix/main.cf \
-	smtpd_data_restrictions=reject_unauth_pipelining
+	smtpd_data_restrictions=reject_unauth_pipelining \
+	smtpd_discard_ehlo_keywords="chunking, silent-discard"
 
 # ### Outgoing Mail
 


### PR DESCRIPTION
Update short term fix according to postfix advisory at https://www.postfix.org/smtp-smuggling.html.